### PR TITLE
Gitlab ci folder remover

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,11 @@ hugo:test:
   - cd $FOLDER
   - hugo
 
+  only:
+    changes:
+      - docs/*
+      - docs/**/*
+
 pages:
   image: registry.gitlab.com/pages/hugo:latest
   stage: documentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,11 @@ variables:
   stage: test
 
   script:
-  - echo $FOLDER
+    - cd $FOLDER
+    - test -f requirements.txt && pip install -r requirements.txt
+    - test -f requirements-dev.txt && pip install -r requirements-dev.txt
+    - pip install pytest # if pytest not installed
+    - pytest
 
   tags:
   -  autoscaling

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,18 @@ variables:
   tags:
   -  autoscaling
 
-  only:
-    changes:
-      - $FOLDER/*
-      - $FOLDER/**/*
+  except:
+    refs:
+      - master
+
+  # https://gitlab.com/gitlab-org/gitlab/issues/8177
+  # not supported currently
+  #only:
+  #  refs:
+  #    - branches
+  #  changes:
+  #    - $FOLDER/*
+  #    - $FOLDER/**/*
 
 .builds:
   stage: build
@@ -30,10 +38,6 @@ variables:
   only:
     refs:
     - master
-
-    changes:
-      - $FOLDER/*
-      - $FOLDER/**/*
 
   services:
     - docker:dind

--- a/RDS/circle1_adapters_and_ports/port_owncloud/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_owncloud/.gitlab-ci.yml
@@ -1,7 +1,12 @@
 .tests_port_owncloud:
   extends: .tests
   variables:
-    FOLDER: RDS/circle1_adapters_and_ports/exporter
+    FOLDER: RDS/circle1_adapters_and_ports/port_owncloud
+
+  only:
+      changes:
+      - RDS/circle1_adapters_and_ports/port_owncloud/*
+      - RDS/circle1_adapters_and_ports/port_owncloud/**/*
 
 test:exporter:
   image: python:3.8

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -1,13 +1,15 @@
-.port_zenodo:
-    variables:
-        ZENODO_API_KEY: $GITLAB_ZENODO_API_KEY
-        FOLDER: RDS/circle1_adapters_and_ports/port_zenodo
-        
 .tests_port_zenodo:
     extends: 
     - .tests
-    - .port_zenodo
 
+    variables:
+        ZENODO_API_KEY: $GITLAB_ZENODO_API_KEY
+        FOLDER: RDS/circle1_adapters_and_ports/port_zenodo
+
+    only:
+        changes:
+        - RDS/circle1_adapters_and_ports/port_zenodo/*
+        - RDS/circle1_adapters_and_ports/port_zenodo/**/*
 
     script:
     - cd $FOLDER

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -18,10 +18,14 @@ test:port_zenodo3.6:
     image: python:3.6
 
 test:port_zenodo3.7:
+    needs:
+        - port_zenodo3.6
     extends: .tests_port_zenodo
     image: python:3.7
 
 test:port_zenodo3.8:
+    needs:
+        - port_zenodo3.7
     extends: .tests_port_zenodo
     image: python:3.8
 

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -1,10 +1,12 @@
-.tests_port_zenodo:
-    extends: 
-    - .tests
-
+.port_zenodo:
     variables:
         ZENODO_API_KEY: $GITLAB_ZENODO_API_KEY
         FOLDER: RDS/circle1_adapters_and_ports/port_zenodo
+
+.tests_port_zenodo:
+    extends: 
+    - .tests
+    - .port_zenodo
 
     only:
         changes:

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -13,12 +13,6 @@
         - RDS/circle1_adapters_and_ports/port_zenodo/*
         - RDS/circle1_adapters_and_ports/port_zenodo/**/*
 
-    script:
-    - cd $FOLDER
-    - pip install -r requirements.txt
-    - pip install -r requirements-dev.txt
-    - python test_zenodo.py
-
 test:port_zenodo3.6:
     extends: .tests_port_zenodo
     image: python:3.6

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -19,13 +19,13 @@ test:port_zenodo3.6:
 
 test:port_zenodo3.7:
     needs:
-        - port_zenodo3.6
+        - test:port_zenodo3.6
     extends: .tests_port_zenodo
     image: python:3.7
 
 test:port_zenodo3.8:
     needs:
-        - port_zenodo3.7
+        - test:port_zenodo3.7
     extends: .tests_port_zenodo
     image: python:3.8
 

--- a/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
+++ b/RDS/circle1_adapters_and_ports/port_zenodo/.gitlab-ci.yml
@@ -8,6 +8,8 @@
     - .tests
     - .port_zenodo
 
+    retry: 2
+
     only:
         changes:
         - RDS/circle1_adapters_and_ports/port_zenodo/*
@@ -18,14 +20,10 @@ test:port_zenodo3.6:
     image: python:3.6
 
 test:port_zenodo3.7:
-    needs:
-        - test:port_zenodo3.6
     extends: .tests_port_zenodo
     image: python:3.7
 
 test:port_zenodo3.8:
-    needs:
-        - test:port_zenodo3.7
     extends: .tests_port_zenodo
     image: python:3.8
 

--- a/RDS/circle2_use_cases/exporter/.gitlab-ci.yml
+++ b/RDS/circle2_use_cases/exporter/.gitlab-ci.yml
@@ -3,6 +3,11 @@
   variables:
     FOLDER: RDS/circle2_use_cases/exporter
 
+  only:
+      changes:
+      - RDS/circle2_use_cases/exporter/*
+      - RDS/circle2_use_cases/exporter/**/*
+
 test:exporter:
   image: python:3.8
   extends: .tests_exporter

--- a/RDS/circle3_central_services/metadata_capture/.gitlab-ci.yml
+++ b/RDS/circle3_central_services/metadata_capture/.gitlab-ci.yml
@@ -3,6 +3,11 @@
   extends: .tests
   variables:
     FOLDER: RDS/circle3_central_services/metadata_capture
+  
+  only:
+      changes:
+      - RDS/circle3_central_services/metadata_capture/*
+      - RDS/circle3_central_services/metadata_capture/**/*
 
 test:metadata_capture:
   extends: .tests_metadata_capture

--- a/RDS/circle3_central_services/project_manager/.gitlab-ci.yml
+++ b/RDS/circle3_central_services/project_manager/.gitlab-ci.yml
@@ -4,5 +4,10 @@
   variables:
       FOLDER: RDS/circle3_central_services/project_manager
 
+  only:
+      changes:
+      - RDS/circle3_central_services/project_manager/*
+      - RDS/circle3_central_services/project_manager/**/*
+
 test:project_manager:
   extends: .tests_project_manager

--- a/RDS/circle3_central_services/token_service/.gitlab-ci.yml
+++ b/RDS/circle3_central_services/token_service/.gitlab-ci.yml
@@ -4,5 +4,10 @@
   variables:
       FOLDER: RDS/circle3_central_services/token_service
 
+  only:
+      changes:
+      - RDS/circle3_central_services/token_service/*
+      - RDS/circle3_central_services/token_service/**/*
+
 test:token_service:
   extends: .tests_token_service


### PR DESCRIPTION
The $folder var is not usable in only:changes in gitlab-ci. So it has to set manually in all jobs.
This pr tries to workaround this.