### PR TITLE
Add build_arg in Dockerfiles

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ variables:
     - export CI_IMAGE_BRANCH=$CI_PROJECT_PATH:$CI_COMMIT_REF_NAME
     - export CI_IMAGE_JOBID=$CI_PROJECT_PATH:$CI_PIPELINE_ID
     - docker pull --quiet $CI_IMAGE_BRANCH || true
-    - docker build --cache-from $CI_IMAGE_BRANCH --tag $CI_IMAGE_LATEST --tag $CI_IMAGE_BRANCH  --tag $CI_IMAGE_JOBID --file="dockerfile" .
+    - docker build --cache-from $CI_IMAGE_BRANCH --tag $CI_IMAGE_LATEST --tag $CI_IMAGE_BRANCH  --tag $CI_IMAGE_JOBID --file="dockerfile" --build-arg git_branch=$CI_COMMIT_BRANCH .
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - docker info
     - docker push $CI_IMAGE_BRANCH

--- a/RDS/layer1_adapters_and_ports/port_openscienceframework/dockerfile
+++ b/RDS/layer1_adapters_and_ports/port_openscienceframework/dockerfile
@@ -10,7 +10,8 @@ RUN pip install -r requirements.txt
 
 ENV OPENAPI_MULTIPLE_FILES      "interface_port_metadata.yml"
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/interface_port_metadata.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/interface_port_metadata.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer1_adapters_and_ports/port_owncloud/dockerfile
+++ b/RDS/layer1_adapters_and_ports/port_owncloud/dockerfile
@@ -11,7 +11,8 @@ RUN pip install -r requirements.txt
 # comma separated
 ENV OPENAPI_MULTIPLE_FILES "interface_port_file_storage.yml"
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/interface_port_file_storage.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/interface_port_file_storage.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer1_adapters_and_ports/port_zenodo/dockerfile
+++ b/RDS/layer1_adapters_and_ports/port_zenodo/dockerfile
@@ -10,7 +10,8 @@ RUN pip install -r requirements.txt
 
 ENV OPENAPI_MULTIPLE_FILES      "interface_port_metadata.yml"
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/interface_port_metadata.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/interface_port_metadata.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer2_use_cases/exporter/dockerfile
+++ b/RDS/layer2_use_cases/exporter/dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 ADD ./requirements.txt ./
 RUN pip install -r requirements.txt
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/exporter/use-case_exporter.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/exporter/use-case_exporter.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer2_use_cases/metadata/dockerfile
+++ b/RDS/layer2_use_cases/metadata/dockerfile
@@ -10,7 +10,8 @@ ADD ./datacite_4.3_schema.json ./
 ADD ./zenodo_schema.json ./
 RUN pip install -r requirements.txt
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/metadata/use-case_metadata.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/metadata/use-case_metadata.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer2_use_cases/port/dockerfile
+++ b/RDS/layer2_use_cases/port/dockerfile
@@ -10,7 +10,8 @@ RUN pip install -r requirements.txt
 
 ENV CENTRAL_SERVICE_TOKEN_STORAGE "http://layer3-token-storage"
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer2_use_cases/port/use-case_port.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer2_use_cases/port/use-case_port.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer3_central_services/research_manager/dockerfile
+++ b/RDS/layer3_central_services/research_manager/dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 ADD ./requirements.txt ./
 RUN pip install -r requirements.txt
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer3_central_services/research_manager/central-service_research-manager.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer3_central_services/research_manager/central-service_research-manager.yml" ./
 
 # now add everything else, which changes often
 ADD src ./

--- a/RDS/layer3_central_services/token_storage/dockerfile
+++ b/RDS/layer3_central_services/token_storage/dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 ADD ./requirements.txt ./
 RUN pip install -r requirements.txt
 
-ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/master/RDS/layer3_central_services/token_storage/central-service_token-storage.yml" ./
+ARG git_branch=release
+ADD "https://raw.githubusercontent.com/Sciebo-RDS/Sciebo-RDS/$git_branch/RDS/layer3_central_services/token_storage/central-service_token-storage.yml" ./
 
 # now add everything else, which changes often
 ADD src ./


### PR DESCRIPTION
WIth this argument, the dockerfile can pull the right interface specification from github. Before this PR, it pulls a constant url, which is not very developer friendly.