### PR TITLE
fix: remove apiKey and fix userId documentation

### DIFF
--- a/RDS/layer2_use_cases/interface_port_metadata.yml
+++ b/RDS/layer2_use_cases/interface_port_metadata.yml
@@ -42,7 +42,7 @@ paths:
                       resourceType: ''
                       resourceTypeGeneral: Poster
       description: |-
-        Take a look at the datacite specification (https://raw.githubusercontent.com/datacite/schema/master/source/json/kernel-4.3/datacite_4.3_schema.json) for all useable keywords. 
+        Take a look at the ro-crate example: https://www.researchobject.org/ro-crate/examples.html
 
         See the examples to see, how to use it.
       requestBody:
@@ -58,7 +58,7 @@ paths:
             examples:
               example-1:
                 value:
-                  userId: admin
+                  userId: <port-name>://<username>:<password>
                   metadata:
                     titles: ''
                     publisher: ''
@@ -66,7 +66,7 @@ paths:
               example-2:
                 value:
                   metadata: {}
-                  userId: admin
+                  userId: <port-name>://<username>:<password>
         description: The metadata request object
     delete:
       summary: Remove a project from this service
@@ -91,15 +91,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/Metadata'
               examples:
-                example-1:
-                  value:
-                    titles:
-                      - title: long title
-                        lang: en
-                    publisher: research publisher gmbh
-                    type:
-                      resourceType: ''
-                      resourceTypeGeneral: Poster
+                example-1: 
+                  value: 
+                    { 
+                      "@context": "https://w3id.org/ro/crate/1.1/context", 
+                      "@graph": [
+                        {
+                            "@type": "CreativeWork",
+                            "@id": "ro-crate-metadata.json",
+                            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+                            "about": {"@id": "./"}
+                        },  
+                        {
+                            "@id": "./",
+                            "identifier": "https://doi.org/10.4225/59/59672c09f4a4b",
+                            "@type": "Dataset",
+                            "datePublished": "2017",
+                            "name": "Data files associated with the manuscript:Effects of facilitated family case conferencing for ...",
+                            "description": "Palliative care planning for nursing home residents with advanced dementia ...",
+                            "license": {"@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/"}
+                        },
+                        {
+                          "@id": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+                          "@type": "CreativeWork",
+                          "description": "This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Australia License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/au/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.",
+                          "identifier": "https://creativecommons.org/licenses/by-nc-sa/3.0/au/",
+                          "name": "Attribution-NonCommercial-ShareAlike 3.0 Australia (CC BY-NC-SA 3.0 AU)"
+                        }
+                      ]
+                    }
       requestBody:
         content:
           application/json:
@@ -115,8 +135,7 @@ paths:
             examples:
               example-1:
                 value:
-                  apiKey: 123
-                  userId: 1
+                  userId: <port-name>://<username>:<password>
                   metadata:
                     titles:
                       - title: long title
@@ -271,7 +290,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Project'
-              examples: {}
+              examples: []
       parameters: []
       requestBody:
         content:
@@ -312,10 +331,10 @@ components:
         Beware: Do not use a token (e.g. for oauth) as password, because this is used in the token field.
 
         session format:
-        <port-name>://<username>:<password>
+        `<port-name>://<username>:<password>`
 
         normal format:
-        <username>
+        `<username>`
     File:
       title: File
       type: object


### PR DESCRIPTION
Fix some minor documentation issues.

1. remove apiKey
2. fix examples for userId
3. fix escaping of `<` and `>` for the usierId example in `portusername` documentation