### PR TITLE
Setting the correct (new) apiVersion

### DIFF
--- a/charts/layer0_describo/templates/ingress.yaml
+++ b/charts/layer0_describo/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "layer0_describo.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/layer0_web/templates/ingress.yaml
+++ b/charts/layer0_web/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "layer0_web.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
I have noticed that in the following yaml files 'charts/layer0_web/templates/ingress.yaml' and 'charts/layer0_describo/templates/ingress.yaml' the apiVersion is set to extension/v1beta1. I needed to change this to 'networking.k8s.io/v1' in order to get succesful builds. So in case anyone is running into issues with the ingress, see if this will fix it.