### PR TITLE
set ingress api version to extensions/v1beta1

### DIFF
--- a/charts/.gitlab-ci.yml
+++ b/charts/.gitlab-ci.yml
@@ -175,5 +175,7 @@ deploy:
     # pull helm deps: https://github.com/helm/helm/issues/2247#issuecomment-998636912
     # workaround issue #206
     - helm delete sciebords
+    # workaround due to old deploy cluster
+    - sed -i -e 's#networking.k8s.io/v1#extensions/v1beta1#g' ./charts/*/templates/ingress.yaml
     - find ./charts -name Chart.yaml -print | sed s/Chart.yaml//g | awk -F"/" '{print NF $0}' | sort -nr | sed 's/^.//' | xargs -n1 helm dep build
     - helm secrets upgrade -i sciebords charts/all --values $HELM_DEPLOY_VALUES --set-string global.image.tag=$CI_PIPELINE_ID


### PR DESCRIPTION
workaround because cluster is old and still has old api version but upstream we want current version