### PR TITLE
show the getting started button in NextCloud

### DIFF
--- a/RDS/layer0_ingress/web/client/packages/codebase/src/components/Frame.vue
+++ b/RDS/layer0_ingress/web/client/packages/codebase/src/components/Frame.vue
@@ -18,6 +18,7 @@
 
     <v-card
       class="text-center pa-2"
+      id="getting-started-button"
       style="width: 100%; position: absolute; bottom: 0px"
       tile
       flat

--- a/RDS/layer0_ingress/web/client/packages/codebase/src/plugins/integration/embed.js
+++ b/RDS/layer0_ingress/web/client/packages/codebase/src/plugins/integration/embed.js
@@ -23,6 +23,14 @@ export default {
                 if (event.data.length > 0) {
                     var payload = JSON.parse(event.data);
                     switch (payload.event) {
+                        case "from-nextcloud":
+                            // NextCloud and OwnCloud provide different layouts,
+                            // and the style for the RDS app is based on the OwnCloud layout.
+                            // In NextCloud, this style results in having the "getting started" button hidden;
+                            // the code below changes the style to show the button.
+                            const buttonElem = document.getElementById("getting-started-button");
+                            buttonElem.style.bottom = "2.5rem";
+                            break;
                         case "informations":
                             let parsed = JSON.parse(payload.data)
                             let info = parsed.jwt


### PR DESCRIPTION
The style of the RDS js app was developed to look good in OwnCloud.
If we load the app from NextCloud, however, the button "getting started" is not visible.
So the code below receives a message from the loading app,
informing it that it is being loaded from NextCloud,
and reacts by moving the button into view.